### PR TITLE
Update to include interpreter version check and to use '1/0' for 'state' resource

### DIFF
--- a/murano_device_simulator.py
+++ b/murano_device_simulator.py
@@ -23,6 +23,7 @@
 #
 
 import os
+import sys
 import time
 import datetime
 import random
@@ -314,6 +315,16 @@ def LONG_POLL_WAIT(READ_PARAMS):
 # --------------------------
 # BOOT
 # --------------------------
+
+# Verify interpreter version is adequate
+req_version = (2,7,11)
+cur_version = sys.version_info
+if cur_version < req_version:
+    print("# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #")
+    print("#        This application must be run using Python 2.7.9 or greater.        #")
+    print("#  You can find the latest releases here: https://www.python.org/downloads/ #")
+    print("# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #")
+    exit()
 
 # Check if CIK locally stored already
 if PROMPT_FOR_PRODUCTID_AND_SN is True or productid == UNSET_PRODUCT_ID:

--- a/murano_device_simulator.py
+++ b/murano_device_simulator.py
@@ -349,7 +349,7 @@ if cik is None:
         STORE_CIK(cik)
         FLAG_CHECK_ACTIVATION = False
         # Set default starting value for state, Off
-        status, resp = WRITE('state=Off')
+        status, resp = WRITE('state=0')
     else:
         FLAG_CHECK_ACTIVATION = True
 
@@ -360,7 +360,7 @@ print("starting main loop")
 
 counter = 100  # for debug purposes so you don't have issues killing this process
 LOOP = True
-lightbulb_state = "Off"
+lightbulb_state = 0
 init = 1
 
 # Check current system expected state
@@ -371,9 +371,11 @@ if not status and resp == 304:
     # print("No New State Value")
     pass
 if status:
+    # Report updated value for state
+    WRITE(resp)
     new_value = resp.split('=')
-    lightbulb_state = new_value[1]
-    if lightbulb_state == "On":
+    lightbulb_state = int(new_value[1])
+    if lightbulb_state == 1:
         print("Light Bulb is On")
     else:
         print("Light Bulb is Off")
@@ -387,7 +389,7 @@ while LOOP:
         connection = "Not Connected"
 
     output_string = (
-        "Connection: {0:s}, Run Time: {1:5d}, Temperature: {2:3.1f} F, Humidity: {3:3.1f} %, Light State: " + lightbulb_state).format(connection, uptime, temperature, humidity)
+        "Connection: {0:s}, Run Time: {1:5d}, Temperature: {2:3.1f} F, Humidity: {3:3.1f} %, Light State: {4:1d}").format(connection, uptime, temperature, humidity, lightbulb_state)
     print("{}".format(output_string))
 
     if cik is not None and not FLAG_CHECK_ACTIVATION:
@@ -420,9 +422,9 @@ while LOOP:
             # print("New State Value: {}".format(str(resp)))
             new_value = resp.split('=')
 
-            if lightbulb_state != new_value[1]:
-                lightbulb_state = new_value[1]
-                if lightbulb_state == "On":
+            if lightbulb_state != int(new_value[1]):
+                lightbulb_state = int(new_value[1])
+                if lightbulb_state == 1:
                     print("Action -> Turn Light Bulb On")
                 else:
                     print("Action -> Turn Light Bulb Off")

--- a/murano_device_simulator.py
+++ b/murano_device_simulator.py
@@ -317,7 +317,7 @@ def LONG_POLL_WAIT(READ_PARAMS):
 # --------------------------
 
 # Verify interpreter version is adequate
-req_version = (2,7,11)
+req_version = (2,7,9)
 cur_version = sys.version_info
 if cur_version < req_version:
     print("# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #")

--- a/murano_device_simulator.py
+++ b/murano_device_simulator.py
@@ -348,7 +348,7 @@ if cik is None:
         cik = act_response
         STORE_CIK(cik)
         FLAG_CHECK_ACTIVATION = False
-        # Set default starting value for state, Off
+        # Report default starting value for state, Off
         status, resp = WRITE('state=Off')
     else:
         FLAG_CHECK_ACTIVATION = True
@@ -371,6 +371,8 @@ if not status and resp == 304:
     # print("No New State Value")
     pass
 if status:
+    # Report updated value for state
+    WRITE(resp)
     new_value = resp.split('=')
     lightbulb_state = new_value[1]
     if lightbulb_state == "On":


### PR DESCRIPTION
Previously if 'state' were "set" while the program was not running, it would read-in the "set" value and display it in the terminal but not "report" it to allow the UI to update.
The necessary write() has been added.